### PR TITLE
feat: add certificates section

### DIFF
--- a/partials/certificates.hbs
+++ b/partials/certificates.hbs
@@ -1,0 +1,19 @@
+{{#if resume.certificates.length}}
+<div id="certificates" class="box">
+	<h2><i class="fa fa-certificate ico"></i> Certificates</h2>
+	{{#each resume.certificates}}
+	<div class="achievement">
+		<div class="header">
+			<h3>{{issuer}}</h3>
+			<p><i class="fa fa-scroll ico"></i> {{name}}</p>
+                        {{#if url}}
+                        <p class="address">
+                                <a href="{{url}}" target= "_blank"><i class="fa fa-globe ico"></i> {{url}}</a>
+                        </p>
+                        {{/if}}
+			<p class="date">{{getMonth date}} {{getYear date}}</p>
+		</div>
+	</div>
+	{{/each}}
+</div>
+{{/if}}

--- a/resume.hbs
+++ b/resume.hbs
@@ -24,6 +24,7 @@
 	<div class="col-xs-12 col-sm-5">
 	    {{> contact }}
 		{{> education }}
+		{{> certificates }}
 		{{> publications }}
 		{{> awards }}
 		{{> skills }}


### PR DESCRIPTION
A certificate section was missing, so I've added one. It uses the same .achievement class that is used for education.

![jsonresume-umennel-theme-certificates-section](https://github.com/user-attachments/assets/f4bf900c-4455-4296-b4dd-5481a8b33ff5)
