### PR TITLE
feat: add studyType after education area

### DIFF
--- a/partials/education.hbs
+++ b/partials/education.hbs
@@ -5,7 +5,7 @@
 	<div class="achievement">
 		<div class="header">
 			<h3>{{institution}}</h3>
-			<p><i class="fa fa-graduation-cap ico"></i> {{area}}</p>
+			<p><i class="fa fa-graduation-cap ico"></i> {{area}}, {{studyType}}</p>
 			<p class="date">{{getYear startDate}} – {{#if endDate}}{{getYear endDate}}{{else}}present{{/if}}</p>
 			{{#if gpa}}<p>GPA: {{gpa}}</p>{{/if}}
 		</div>


### PR DESCRIPTION
So, instead of showing just "Computer Science", we now show "Computer Science, MSc" (if "MSc" was set as studyType). Since we have that information, I want to show it.

![education-studytype](https://github.com/user-attachments/assets/b1720e36-343d-43a3-9b3b-d0b57150e49b)
